### PR TITLE
fix: logo on mobile version showing broken image (Issue-#28)

### DIFF
--- a/src/app/components/cardsSection/cards.module.css
+++ b/src/app/components/cardsSection/cards.module.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap");
 
 .cardContainer {
   display: flex;

--- a/src/app/components/navbar/navbar.tsx
+++ b/src/app/components/navbar/navbar.tsx
@@ -27,7 +27,7 @@ export default function Navbar({ label }: NavbarProps) {
           <Link href="/">
             <div className={styles.homeLink}>
               <Image
-                src="/public/assets/dsd-circle-logo.png"
+                src="/assets/dsd-circle-logo.png"
                 alt="Logo"
                 width={45}
                 height={45}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,1 +1,1 @@
-@import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap");


### PR DESCRIPTION
# fix: logo on mobile version showing broken image: #28 
The problem is in the path, removing `/public` will fix the error. I realized this when I was working on PR #10 