### PR TITLE
chore: Hide Video Playing section in mobile view (WEB-23)

### DIFF
--- a/src/app/components/heroSection/heroSection.module.css
+++ b/src/app/components/heroSection/heroSection.module.css
@@ -74,6 +74,7 @@
     max-width: 430px;
   }
   .videoPlaceholder {
+    display: none;
     flex: unset;
     width: 80%;
     height: auto;


### PR DESCRIPTION
- Added `display:none` property when `width` goes below `690 px`