### PR TITLE
chore: create tests for Navbar and Button to increase coverage (WEB-38)

### DIFF
--- a/src/app/components/button/__snapshots__/button.test.js.snap
+++ b/src/app/components/button/__snapshots__/button.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders correctly with non-primary variant 1`] = `
+<DocumentFragment>
+  <button
+    class="button "
+    data-testid="button-secondary"
+  >
+    Secondary Button
+  </button>
+</DocumentFragment>
+`;
+
 exports[`renders correctly with primary variant 1`] = `
 <DocumentFragment>
   <button

--- a/src/app/components/button/button.test.js
+++ b/src/app/components/button/button.test.js
@@ -27,6 +27,13 @@ test('renders correctly with primary variant', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
+test('renders correctly with non-primary variant', () => {
+  const { asFragment } = render(
+    <Button buttonText='Secondary Button' variant='secondary' />
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+
 test('shows icon when showIcon is true', () => {
   render(<Button buttonText='Button with Icon' showIcon />);
   const iconElement = screen.getByTestId('button-icon');

--- a/src/app/components/navbar/navbar.test.js
+++ b/src/app/components/navbar/navbar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import Navbar from './navbar';
 
 describe('Navbar', () => {
@@ -34,5 +34,22 @@ describe('Navbar', () => {
     expect(navbarElement).toHaveTextContent('Community Impact');
     expect(navbarElement).toHaveTextContent('Contact Us');
     expect(navbarElement).toHaveTextContent('Meetups');
+  });
+
+  test('navbar toggles when expand/collapse button is pressed', () => {
+    const component = render(
+      <Navbar
+        label={{
+          lblHome: 'Dallas Software Developers',
+          lblCommunity: 'Community Impact',
+          lblContact: 'Contact Us',
+          lblMeetup: 'Meetups',
+        }}
+      />
+    );
+    expect(component.getByTestId('navbar-expand')).toBeInTheDocument();
+    fireEvent.click(component.getByTestId('navbar-expand'));
+    expect(component.getByTestId('navbar-collapse')).toBeInTheDocument();
+    fireEvent.click(component.getByTestId('navbar-collapse'));
   });
 });

--- a/src/app/components/navbar/navbar.tsx
+++ b/src/app/components/navbar/navbar.tsx
@@ -38,13 +38,21 @@ export default function Navbar({ label }: NavbarProps) {
         </div>
         {isNavVisible ? (
           <div className={styles.crossContainer}>
-            <div onClick={toggleNav} className={styles.cross} data-testid='navbar-collapse'>
+            <div
+              onClick={toggleNav}
+              className={styles.cross}
+              data-testid='navbar-collapse'
+            >
               <div className={styles.line}></div>
               <div className={styles.line}></div>
             </div>
           </div>
         ) : (
-          <div className={styles.hamburger} onClick={toggleNav} data-testid='navbar-expand'>
+          <div
+            className={styles.hamburger}
+            onClick={toggleNav}
+            data-testid='navbar-expand'
+          >
             <div className={styles.line}></div>
             <div className={styles.line}></div>
             <div className={styles.line}></div>

--- a/src/app/components/navbar/navbar.tsx
+++ b/src/app/components/navbar/navbar.tsx
@@ -38,13 +38,13 @@ export default function Navbar({ label }: NavbarProps) {
         </div>
         {isNavVisible ? (
           <div className={styles.crossContainer}>
-            <div onClick={toggleNav} className={styles.cross}>
+            <div onClick={toggleNav} className={styles.cross} data-testid='navbar-collapse'>
               <div className={styles.line}></div>
               <div className={styles.line}></div>
             </div>
           </div>
         ) : (
-          <div className={styles.hamburger} onClick={toggleNav}>
+          <div className={styles.hamburger} onClick={toggleNav} data-testid='navbar-expand'>
             <div className={styles.line}></div>
             <div className={styles.line}></div>
             <div className={styles.line}></div>


### PR DESCRIPTION
Added tests to increase coverage to 100% for Button and Navbar components.
![image](https://github.com/dallassoftwaredevelopers/DSDsite/assets/39107451/024e5f94-7706-43d4-805d-a01b9e549916)

Navbar Test:
Added a test that simulates a click to toggle the icon. Checks if the desired icon is visible or not.

Button Test:
Added a test that checks if the correct button type is rendered if it isn't a primary variant.