### PR TITLE
#74 chore: bento box image section (WEB-36)

### DIFF
--- a/src/app/components/bentoSection/bento.module.css
+++ b/src/app/components/bentoSection/bento.module.css
@@ -17,19 +17,25 @@
   justify-content: space-evenly;
 }
 
-.bentoThirdContainer {
+.bentoFourthContainer {
   padding-top: 1rem;
   display: flex;
 }
 
-.bentoThirdContainer .card {
-  padding: 0rem;
-  margin: 0rem;
-}
-
-.bentoThirdContainer .card {
+.bentoFourthContainer .card {
   padding: 0rem;
   margin: 0 1rem;
+}
+
+.bentoThirdContainer .imageContainer {
+  padding: 0 0.9rem;
+}
+
+.bentoThirdContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 .imageContainer {

--- a/src/app/components/bentoSection/bento.module.css
+++ b/src/app/components/bentoSection/bento.module.css
@@ -1,0 +1,83 @@
+@import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
+
+.card {
+  padding: 1rem 0;
+  height: 184px;
+  border-radius: 4px;
+  display: flex;
+}
+
+.firstCard {
+  height: 100%;
+}
+
+.cardContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
+
+.bentoThirdContainer {
+  padding-top: 1rem;
+  display: flex;
+}
+
+.bentoThirdContainer .card {
+  padding: 0rem;
+  margin: 0rem;
+}
+
+.bentoThirdContainer .card {
+  padding: 0rem;
+  margin: 0 1rem;
+}
+
+.imageContainer {
+  display: flex;
+  max-height: 250px;
+  height: 100%;
+  max-width: 775px;
+  width: 100%;
+}
+
+.imageStyle {
+  object-fit: fill;
+  border-radius: 10px;
+  border: 3px solid #3c3db9;
+  box-shadow: 8px 10px 10px 0px #00000040;
+  width: 100%;
+  height: auto;
+}
+
+@media (max-width: 1300px) {
+  .cardContainer {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .card {
+    margin-bottom: 30px;
+  }
+
+  .cardHeader {
+    font-size: 24px;
+  }
+}
+
+@media (max-width: 375px) {
+  .cardContainer {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 786px) {
+  .imageContainer {
+    max-height: 245px;
+    height: 100%;
+    max-width: 330px;
+  }
+
+  .imageStyle {
+    max-width: 90%;
+  }
+}

--- a/src/app/components/bentoSection/bento.tsx
+++ b/src/app/components/bentoSection/bento.tsx
@@ -1,0 +1,9 @@
+import styles from './bento.module.css';
+
+interface BentoProps {
+  children: React.ReactNode;
+}
+
+export default function Bento({ children }: BentoProps) {
+  return <div className={styles.card}>{children}</div>;
+}

--- a/src/app/components/bentoSection/bentoSection.tsx
+++ b/src/app/components/bentoSection/bentoSection.tsx
@@ -8,7 +8,7 @@ interface BentoData {
   alt: string;
 }
 
-const bentoImages = [
+const bentoImages: BentoData[] = [
   {
     id: 1,
     url: '/assets/twoPeopleHelp.png',
@@ -83,7 +83,7 @@ export default function BentoSection() {
         ))}
       </div>
 
-      <div className={styles.bentoFourthContainer}>
+      <div className={styles.bentoThirdContainer}>
         <Bento key={bentoImages[5].id}>
           <div className={styles.imageContainer}>
             <Image
@@ -96,7 +96,7 @@ export default function BentoSection() {
           </div>
         </Bento>
 
-        <div className={styles.bentoThirdContainer}>
+        <div className={styles.bentoFourthContainer}>
           <Bento key={bentoImages[6].id}>
             <div>
               <Image

--- a/src/app/components/bentoSection/bentoSection.tsx
+++ b/src/app/components/bentoSection/bentoSection.tsx
@@ -1,0 +1,127 @@
+import Bento from './bento';
+import styles from './bento.module.css';
+import Image from 'next/image';
+
+interface BentoData {
+  id: number;
+  url: string;
+  alt: string;
+}
+
+const bentoImages = [
+  {
+    id: 1,
+    url: '/assets/twoPeopleHelp.png',
+    alt: 'two people help',
+  },
+  {
+    id: 2,
+    url: '/assets/meetupGroupShot1.png',
+    alt: 'meetup group picture 1',
+  },
+  {
+    id: 3,
+    url: '/assets/meetupGroupShot2.png',
+    alt: 'meetup group picture 2',
+  },
+  {
+    id: 4,
+    url: '/assets/meetupGroupShot3.png',
+    alt: 'meetup group picture 3',
+  },
+  {
+    id: 5,
+    url: '/assets/meetupGroupShot4.png',
+    alt: 'meetup group picture 4',
+  },
+  {
+    id: 6,
+    url: '/assets/meetupGroupShot5.png',
+    alt: 'meetup group picture 5',
+  },
+  {
+    id: 7,
+    url: '/assets/twoPeopleHelpLaptop.png',
+    alt: 'two people help on laptop',
+  },
+  {
+    id: 8,
+    url: '/assets/groupTableLaptop.png',
+    alt: 'group table collaborating with laptops',
+  },
+];
+
+export default function BentoSection() {
+  return (
+    <div className={styles.cardContainer}>
+      <Bento key={bentoImages[0].id}>
+        <div>
+          <Image
+            className={styles.imageStyle}
+            src={bentoImages[0].url}
+            alt={bentoImages[0].alt}
+            width={575}
+            height={750}
+          />
+        </div>
+      </Bento>
+
+      <div className={styles.bentoImages}>
+        {bentoImages.slice(1, 4).map((card) => (
+          <Bento key={card.id}>
+            <div className={styles.imageContainer}>
+              <Image
+                src={card.url}
+                alt={card.alt}
+                className={styles.imageStyle}
+                sizes='400vw'
+                width={575}
+                height={450}
+              />
+            </div>
+          </Bento>
+        ))}
+      </div>
+
+      <div className={styles.bentoFourthContainer}>
+        <Bento key={bentoImages[5].id}>
+          <div className={styles.imageContainer}>
+            <Image
+              className={styles.imageStyle}
+              src={bentoImages[5].url}
+              alt={bentoImages[5].alt}
+              width={475}
+              height={450}
+            />
+          </div>
+        </Bento>
+
+        <div className={styles.bentoThirdContainer}>
+          <Bento key={bentoImages[6].id}>
+            <div>
+              <Image
+                className={styles.imageStyle}
+                src={bentoImages[6].url}
+                alt={bentoImages[6].alt}
+                width={575}
+                height={750}
+              />
+            </div>
+          </Bento>
+
+          <Bento key={bentoImages[7].id}>
+            <div>
+              <Image
+                className={styles.imageStyle}
+                src={bentoImages[7].url}
+                alt={bentoImages[7].alt}
+                width={575}
+                height={750}
+              />
+            </div>
+          </Bento>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import BannerSection from './components/bannerSection/bannerSection';
 import HeroSection from './components/heroSection/heroSection';
 import Navbar from './components/navbar/navbar';
 import styles from './page.module.css';
+import BentoSection from './components/bentoSection/bentoSection';
 
 export default function Home() {
   const labelMap = {
@@ -41,6 +42,7 @@ export default function Home() {
       <HeroSection label={labelMap.lblHero} />
       <BannerSection label={labelMap} />
       <CardsSection label={labelMap} />
+      <BentoSection />
     </main>
   );
 }


### PR DESCRIPTION
Currently working on issue #74 chore: bento box image section (WEB-36) 

At the moment, I'm very close to replicating what is on the Figma design but I just can't quite figure out how to get those final two images on the bottom right corner of the bento box to align to the horizontal image above it.  And you might notice that the horizontal image above it is also a bit stretched, which was unintentional but I was trying to add white space between the two vertical images.  Does anyone have any suggestions on what I could do to accomplish this?  I have tried the following:

flex, justify-content, align-items, padding, margin, position right/left on the parent div element of the img
flex, justify-content, align-items, padding, margin, position right/left on the parent parent div element of the img
flex, justify-content, align-items, padding, margin, position right/left on the img element
changing the width/height on the Image component and the img tag

![Screenshot 2024-03-30 160517](https://github.com/dallassoftwaredevelopers/DSDsite/assets/66279068/8ec55c37-424e-4064-a456-33f1032e5850)
