### PR TITLE
chore: create the join or discord and other social links section  (WEB-34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.1.1",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^5.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.24.0",
@@ -8138,6 +8139,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.1.0.tgz",
+      "integrity": "sha512-D3zug1270S4hbSlIRJ0CUS97QE1yNNKDjzQe3HqY0aefp2CBn9VgzgES27sRR2gOvFK+0CNx/BW0ggOESp6fqQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "next": "14.1.1",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-icons": "^5.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.0",

--- a/src/app/components/socialSection/socialLinks.tsx
+++ b/src/app/components/socialSection/socialLinks.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import { IconContext } from 'react-icons';
 import { SocialLinkData } from './socialSection';
 import styles from './socialSection.module.css';
 
@@ -8,15 +8,17 @@ interface SocialLinksProps {
 
 const SocialLinks = ({ links }: SocialLinksProps) => {
   return (
-    <ul className={styles.socialLinks}>
-      {links.map((link) => (
-        <li key={link.id}>
-          <a href={link.link} target='_blank'>
-            <Image src={link.imgSrc} alt={link.alt} width={100} height={100} />
-          </a>
-        </li>
-      ))}
-    </ul>
+    <IconContext.Provider value={{ color: 'black', size: '7rem' }}>
+      <ul className={styles.socialLinks}>
+        {links.map((link) => (
+          <li key={link.id}>
+            <a href={link.link} target='_blank'>
+              {link.icon}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </IconContext.Provider>
   );
 };
 

--- a/src/app/components/socialSection/socialLinks.tsx
+++ b/src/app/components/socialSection/socialLinks.tsx
@@ -1,0 +1,23 @@
+import Image from 'next/image';
+import { SocialLinkData } from './socialSection';
+import styles from './socialSection.module.css';
+
+interface SocialLinksProps {
+  links: SocialLinkData[];
+}
+
+const SocialLinks = ({ links }: SocialLinksProps) => {
+  return (
+    <ul className={styles.socialLinks}>
+      {links.map((link) => (
+        <li key={link.id}>
+          <a href={link.link} target='_blank'>
+            <Image src={link.imgSrc} alt={link.alt} width={100} height={100} />
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default SocialLinks;

--- a/src/app/components/socialSection/socialSection.module.css
+++ b/src/app/components/socialSection/socialSection.module.css
@@ -1,0 +1,35 @@
+.socialSection {
+  display: flex;
+  gap: 4rem;
+  align-items: center;
+  padding: 60px 60px 60px 0;
+}
+
+.socialSection p {
+  font-family: 'Raleway', sans-serif;
+  font-size: 55px;
+}
+
+.imageContainer {
+  display: flex;
+  align-items: center;
+  justify-content: start;
+  width: 50%;
+  height: 500px;
+  background-color: #0f1034;
+  border-radius: 0 30px 30px 0;
+}
+
+.imageContainer img {
+  border-radius: 0 15px 15px 0;
+  width: 93%;
+  height: 90%;
+}
+
+.socialLinks {
+  display: flex;
+  gap: 2.5rem;
+  justify-content: space-evenly;
+  list-style: none;
+  padding: 0;
+}

--- a/src/app/components/socialSection/socialSection.test.js
+++ b/src/app/components/socialSection/socialSection.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import SocialSection from './socialSection';
+
+describe('SocialSection', () => {
+  const mockData = [
+    {
+      id: 'github',
+      imgSrc: '/assets/githubIcon.png',
+      alt: 'Github social icon',
+      link: 'https://github.com',
+    },
+    {
+      id: 'discord',
+      imgSrc: '/assets/discordIcon.png',
+      alt: 'Discord social icon',
+      link: 'https://discord.com',
+    },
+    {
+      id: 'meetup',
+      imgSrc: '/assets/meetupIcon.png',
+      alt: 'Meetup social icon',
+      link: '/',
+    },
+    {
+      id: 'linkedin',
+      imgSrc: '/assets/linkedinIcon.png',
+      alt: 'LinkedIn social icon',
+      link: '/',
+    },
+  ];
+
+  test('renders SocialSection component', () => {
+    render(<SocialSection socialData={mockData} />);
+
+    const socialSection = screen.getByTestId('socialSection');
+    expect(socialSection).toBeInTheDocument();
+  });
+
+  test('renders all social icons', () => {
+    render(<SocialSection socialData={mockData} />);
+
+    const linkList = screen.getAllByRole('listitem');
+    expect(linkList).toHaveLength(4);
+  });
+});

--- a/src/app/components/socialSection/socialSection.tsx
+++ b/src/app/components/socialSection/socialSection.tsx
@@ -4,6 +4,7 @@ import styles from './socialSection.module.css';
 
 export interface SocialLinkData {
   id: string;
+  icon: React.ReactNode;
   imgSrc: string;
   alt: string;
   link: string;

--- a/src/app/components/socialSection/socialSection.tsx
+++ b/src/app/components/socialSection/socialSection.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image';
+import SocialLinks from './socialLinks';
+import styles from './socialSection.module.css';
+
+export interface SocialLinkData {
+  id: string;
+  imgSrc: string;
+  alt: string;
+  link: string;
+}
+
+interface SocialSectionProps {
+  socialData: SocialLinkData[];
+}
+
+export default function SocialSection({ socialData }: SocialSectionProps) {
+  return (
+    <div className={styles.socialSection} data-testid='socialSection'>
+      <div className={styles.imageContainer}>
+        <Image
+          src='/assets/joinOurDiscord.png'
+          alt=''
+          width={500}
+          height={350}
+        />
+      </div>
+      <div>
+        <p>
+          Join our Discord and <br /> other social links!
+        </p>
+        <p>
+          This is YOUR community,
+          <br /> be a part of it!
+        </p>
+        <SocialLinks links={socialData} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/hooks/useMediaQuery/README.md
+++ b/src/app/hooks/useMediaQuery/README.md
@@ -1,0 +1,7 @@
+This is a slimmer version of the `useMediaQuery` hook from [useHooks-ts](https://usehooks-ts.com/react-hook/use-media-query)
+
+This hook uses the [`matchMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) method of the `Window` object to check for matching conditions against a media query passed into the hook.
+
+`useMediaQuery` takes a media query argument passed as a string:
+
+`useMediaQuery('(max-width: 750px)')`

--- a/src/app/hooks/useMediaQuery/index.tsx
+++ b/src/app/hooks/useMediaQuery/index.tsx
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const useMediaQuery = (query: string): boolean => {
+  const [isMatch, setIsMatch] = useState<boolean>(false);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    setIsMatch(mediaQueryList.matches);
+
+    mediaQueryList.onchange = (event) => {
+      setIsMatch(event.matches);
+    };
+  }, [query]);
+
+  return isMatch;
+};
+
+export default useMediaQuery;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import { FaDiscord, FaGithub, FaLinkedin, FaMeetup } from 'react-icons/fa';
 import useMediaQuery from './hooks/useMediaQuery';
 import CardsSection from './components/cardsSection/cardsSection';
 import BannerSection from './components/bannerSection/bannerSection';
@@ -45,24 +45,28 @@ export default function Home() {
   const socialData = [
     {
       id: 'github',
+      icon: <FaGithub />,
       imgSrc: '/assets/githubIcon.png',
       alt: 'Github social icon',
       link: labelMap.githubUrl,
     },
     {
       id: 'discord',
+      icon: <FaDiscord />,
       imgSrc: '/assets/discordIcon.png',
       alt: 'Discord social icon',
       link: labelMap.discordUrl,
     },
     {
       id: 'meetup',
+      icon: <FaMeetup />,
       imgSrc: '/assets/meetupIcon.png',
       alt: 'Meetup social icon',
       link: labelMap.meetupUrl,
     },
     {
       id: 'linkedin',
+      icon: <FaLinkedin />,
       imgSrc: '/assets/linkedinIcon.png',
       alt: 'LinkedIn social icon',
       link: labelMap.linkedinUrl,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,11 @@
+'use client';
+
+import useMediaQuery from './hooks/useMediaQuery';
 import CardsSection from './components/cardsSection/cardsSection';
 import BannerSection from './components/bannerSection/bannerSection';
 import HeroSection from './components/heroSection/heroSection';
 import Navbar from './components/navbar/navbar';
+import SocialSection from './components/socialSection/socialSection';
 import styles from './page.module.css';
 
 export default function Home() {
@@ -33,7 +37,39 @@ export default function Home() {
     meetupUrl: 'https://www.meetup.com/dallas-software-developers-meetup/',
     communityUrl: '/',
     cohortUrl: '/',
+    githubUrl: 'https://github.com/dallassoftwaredevelopers',
+    discordUrl: '/',
+    linkedinUrl: '/',
   };
+
+  const socialData = [
+    {
+      id: 'github',
+      imgSrc: '/assets/githubIcon.png',
+      alt: 'Github social icon',
+      link: labelMap.githubUrl,
+    },
+    {
+      id: 'discord',
+      imgSrc: '/assets/discordIcon.png',
+      alt: 'Discord social icon',
+      link: labelMap.discordUrl,
+    },
+    {
+      id: 'meetup',
+      imgSrc: '/assets/meetupIcon.png',
+      alt: 'Meetup social icon',
+      link: labelMap.meetupUrl,
+    },
+    {
+      id: 'linkedin',
+      imgSrc: '/assets/linkedinIcon.png',
+      alt: 'LinkedIn social icon',
+      link: labelMap.linkedinUrl,
+    },
+  ];
+
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
 
   return (
     <main className={styles.main}>
@@ -41,6 +77,7 @@ export default function Home() {
       <HeroSection label={labelMap.lblHero} />
       <BannerSection label={labelMap} />
       <CardsSection label={labelMap} />
+      {isDesktop && <SocialSection socialData={socialData} />}
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,9 +83,9 @@ export default function Home() {
       <HeroSection label={labelMap.lblHero} />
       <BannerSection label={labelMap} />
       <CardsSection label={labelMap} />
+      {isDesktop && <SocialSection socialData={socialData} />}
       <GroupPhotoSection label='' />
       <BentoSection />
-      {isDesktop && <SocialSection socialData={socialData} />}
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
     cohortUrl: '/',
     githubUrl: 'https://github.com/dallassoftwaredevelopers',
     discordUrl: '/',
-    linkedinUrl: '/',
+    linkedinUrl: 'https://www.linkedin.com/company/dallas-software-developers',
   };
 
   const socialData = [


### PR DESCRIPTION
This adds the Discord and social links section to site:

![CleanShot 2024-04-11 at 01 53 48@2x](https://github.com/dallassoftwaredevelopers/DSDsite/assets/49492414/0d38335c-5eb9-441a-b786-ec1b44dfa700)

To build this out, the following components were created:

`SocialSection` - container for section and media + copy

`SocialLinks` - renders social icon images and associated links

Based on Figma, it appears this section is hidden in the mobile view so conditional rendering is set for the component.

Resolves issue #72 