### PR TITLE
fix: proper prop propagation (WEB-53)

### DIFF
--- a/src/app/components/offeringCard/offeringCard.tsx
+++ b/src/app/components/offeringCard/offeringCard.tsx
@@ -1,6 +1,6 @@
 import styles from './offeringCard.module.css';
 
-const defaultText = "Want to become a speaker at an event?"
+const defaultText = 'Want to become a speaker at an event?';
 
 interface OfferingCardProps {
   text?: string;
@@ -16,9 +16,7 @@ export default function OfferingCard({
   return (
     <div className={styles.offeringCard}>
       <div className={styles.textContainer}>
-        <p className={styles.text}>
-          {text || defaultText}
-        </p>
+        <p className={styles.text}>{text || defaultText}</p>
       </div>
       <a href={buttonLink} className={styles.button}>
         {buttonText}

--- a/src/app/components/offeringCard/offeringCard.tsx
+++ b/src/app/components/offeringCard/offeringCard.tsx
@@ -1,7 +1,9 @@
 import styles from './offeringCard.module.css';
 
+const defaultText = "Want to become a speaker at an event?"
+
 interface OfferingCardProps {
-  text: string;
+  text?: string;
   buttonText: string;
   buttonLink: string;
 }
@@ -14,7 +16,9 @@ export default function OfferingCard({
   return (
     <div className={styles.offeringCard}>
       <div className={styles.textContainer}>
-        <p className={styles.text}>Want to become a speaker at an event?</p>
+        <p className={styles.text}>
+          {text || defaultText}
+        </p>
       </div>
       <a href={buttonLink} className={styles.button}>
         {buttonText}

--- a/src/app/components/offeringCard/offeringCard.tsx
+++ b/src/app/components/offeringCard/offeringCard.tsx
@@ -1,9 +1,7 @@
 import styles from './offeringCard.module.css';
 
-const defaultText = 'Want to become a speaker at an event?';
-
 interface OfferingCardProps {
-  text?: string;
+  text: string;
   buttonText: string;
   buttonLink: string;
 }
@@ -16,7 +14,7 @@ export default function OfferingCard({
   return (
     <div className={styles.offeringCard}>
       <div className={styles.textContainer}>
-        <p className={styles.text}>{text || defaultText}</p>
+        {text && <p className={styles.text}>{text}</p>}
       </div>
       <a href={buttonLink} className={styles.button}>
         {buttonText}


### PR DESCRIPTION
Quick fix to have the OfferingCard prop "text" fall through to the <p> tag and set a default text if not.