### PR TITLE
(WEB-62) Fix: Cohorts page formatting

### DIFF
--- a/src/app/cohorts/cohorts.module.css
+++ b/src/app/cohorts/cohorts.module.css
@@ -49,7 +49,7 @@
   font-family: Raleway;
   text-align: center;
   font-weight: 700;
-  max-width: 70%;
+  max-width: 80%;
   margin: auto;
 }
 

--- a/src/app/cohorts/cohorts.module.css
+++ b/src/app/cohorts/cohorts.module.css
@@ -10,6 +10,7 @@
 }
 
 .titleSection {
+  margin-bottom: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -37,22 +38,23 @@
 }
 
 .paragraphBox {
-  padding: 2rem;
-  margin: auto;
+  padding: 0 2rem;
+  margin: 0 auto;
+  margin-bottom: 1rem;
 }
 
 .cohortsParagraph {
-  padding: 1rem 0;
-  font-size: 24px;
+  padding: 1.5rem 0;
+  font-size: 1.5rem;
   font-family: Raleway;
   text-align: center;
   font-weight: 700;
-  max-width: 100%;
+  max-width: 70%;
   margin: auto;
 }
 
 .cohortSection {
-  margin: 0 auto;
+  margin-bottom: 2rem;
   padding: 1rem 0;
 }
 
@@ -110,10 +112,6 @@
   }
 
   .cohortsParagraph {
-    padding: 0;
-    padding-top: 1.5rem;
-    font-size: 1.2rem;
-    font-weight: 400;
     max-width: 100%;
   }
 
@@ -148,15 +146,10 @@
   }
 
   .paragraphBox {
-    padding: 0 2rem;
     margin: 1rem 0 2rem 0;
   }
 
   .cohortsParagraph {
-    padding: 0;
-    padding-top: 1.5rem;
-    font-size: 1.2rem;
-    font-weight: 400;
     max-width: 100%;
   }
 

--- a/src/app/cohorts/page.tsx
+++ b/src/app/cohorts/page.tsx
@@ -109,7 +109,6 @@ export default function CohortPage() {
               key={cohort.id}
               cohortName={cohort.cohortName}
               youtubeLink={cohort.youtubeLink}
-              githubLink={cohort.githubLink}
             />
           ))}
         </div>

--- a/src/app/cohorts/page.tsx
+++ b/src/app/cohorts/page.tsx
@@ -73,7 +73,7 @@ export default function CohortPage() {
         <h1 className={styles.title}>Cohorts</h1>
 
         <div className={styles.paragraphBox}>
-          <p className={styles.cohortsParagraph}>{cohortsText[0]}</p>
+          <p className={`.mdText ${styles.cohortsParagraph}`}>{cohortsText[0]}</p>
           <p className={styles.cohortsParagraph}>{cohortsText[1]}</p>
           <p className={styles.cohortsParagraph}>{cohortsText[2]}</p>
         </div>

--- a/src/app/cohorts/page.tsx
+++ b/src/app/cohorts/page.tsx
@@ -73,7 +73,9 @@ export default function CohortPage() {
         <h1 className={styles.title}>Cohorts</h1>
 
         <div className={styles.paragraphBox}>
-          <p className={`.mdText ${styles.cohortsParagraph}`}>{cohortsText[0]}</p>
+          <p className={`.mdText ${styles.cohortsParagraph}`}>
+            {cohortsText[0]}
+          </p>
           <p className={styles.cohortsParagraph}>{cohortsText[1]}</p>
           <p className={styles.cohortsParagraph}>{cohortsText[2]}</p>
         </div>

--- a/src/app/components/cohortCard/cohortCard.tsx
+++ b/src/app/components/cohortCard/cohortCard.tsx
@@ -41,7 +41,7 @@ export default function CohortCard({
 
   return (
     <div className={styles.cohortContainer}>
-      {cohortName && <h3 className={styles.groupName}>{cohortName}</h3>}
+      {cohortName && <h4 className={styles.groupName}>{cohortName}</h4>}
       {VideoEmbed}
     </div>
   );


### PR DESCRIPTION
* Changes to CSS to prevent container overflows in media queries, tested at 1080px width and under
* Swap cohort video headings to H4 tag from H3 tag
* Let globals.css control font size of upper paragraphs