### PR TITLE
chore: fix typo on about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -20,7 +20,7 @@ export default function AboutPage() {
           />
         </div>
         <p>
-          Explore what Dallas Software Developers as to offer and become an
+          Explore what Dallas Software Developers has to offer and become an
           integral part of our dynamic community. Whether you&apos;re passionate
           about coding, eager to contribute to open-source projects, or simply
           looking to connect with like-minded individuals, there&apos;s a place


### PR DESCRIPTION
Fixed the typo on the about page. From `Explore what Dallas Software Developers as to offer`  to ` Explore what Dallas Software Developers has to offer`.

![fixed typo on about page](https://github.com/user-attachments/assets/ce289765-9f07-4296-af97-36d85259575f)
