### PR TITLE
chore: add aria-label for svg icons WEB-114

### DIFF
--- a/src/app/_constants.tsx
+++ b/src/app/_constants.tsx
@@ -29,28 +29,28 @@ export const externalLinks = {
 export const socialData = [
   {
     id: 'github',
-    icon: <FaGithub />,
+    icon: <FaGithub aria-label='Github'/>,
     imgSrc: '/assets/githubIcon.png',
     alt: 'Github social icon',
     link: externalLinks.githubUrl,
   },
   {
     id: 'discord',
-    icon: <FaDiscord />,
+    icon: <FaDiscord aria-label="Discord" />,
     imgSrc: '/assets/discordIcon.png',
     alt: 'Discord social icon',
     link: externalLinks.discordUrl,
   },
   {
     id: 'meetup',
-    icon: <FaMeetup />,
+    icon: <FaMeetup aria-label="Meetup" />,
     imgSrc: '/assets/meetupIcon.png',
     alt: 'Meetup social icon',
     link: externalLinks.meetupUrl,
   },
   {
     id: 'linkedin',
-    icon: <FaLinkedin />,
+    icon: <FaLinkedin aria-label="Linkedin" />,
     imgSrc: '/assets/linkedinIcon.png',
     alt: 'LinkedIn social icon',
     link: externalLinks.linkedinUrl,

--- a/src/app/_constants.tsx
+++ b/src/app/_constants.tsx
@@ -29,28 +29,28 @@ export const externalLinks = {
 export const socialData = [
   {
     id: 'github',
-    icon: <FaGithub aria-label='Github'/>,
+    icon: <FaGithub aria-label='Github' />,
     imgSrc: '/assets/githubIcon.png',
     alt: 'Github social icon',
     link: externalLinks.githubUrl,
   },
   {
     id: 'discord',
-    icon: <FaDiscord aria-label="Discord" />,
+    icon: <FaDiscord aria-label='Discord' />,
     imgSrc: '/assets/discordIcon.png',
     alt: 'Discord social icon',
     link: externalLinks.discordUrl,
   },
   {
     id: 'meetup',
-    icon: <FaMeetup aria-label="Meetup" />,
+    icon: <FaMeetup aria-label='Meetup' />,
     imgSrc: '/assets/meetupIcon.png',
     alt: 'Meetup social icon',
     link: externalLinks.meetupUrl,
   },
   {
     id: 'linkedin',
-    icon: <FaLinkedin aria-label="Linkedin" />,
+    icon: <FaLinkedin aria-label='Linkedin' />,
     imgSrc: '/assets/linkedinIcon.png',
     alt: 'LinkedIn social icon',
     link: externalLinks.linkedinUrl,


### PR DESCRIPTION
- Adds aria-label to svg icons on the website

Screenshots from updated labels
![image](https://github.com/user-attachments/assets/db21b0d6-bb02-4bd1-8422-04c2dfe96560)
![image](https://github.com/user-attachments/assets/14fa0060-eaf5-442f-a8d5-51564c1af025)

I did check there are no visible SVG icons, apart from the social media icons on two sections, and both of them are updated.