### PR TITLE
chore: rework the header navigation in mobile view (WEB-125)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "eslint-config-next": "14.1.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.5.0",
         "typescript": "^5"
       }
     },
@@ -8464,10 +8464,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.0.tgz",
+      "integrity": "sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-next": "14.1.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.5.0",
     "typescript": "^5"
   }
 }

--- a/src/app/components/navbar/navbar.module.css
+++ b/src/app/components/navbar/navbar.module.css
@@ -139,6 +139,7 @@
     right: 0;
     z-index: 100;
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
     align-items: center;
     padding: 10px 20px;
@@ -146,6 +147,21 @@
     border-bottom: #eeeeee 1px solid;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     box-sizing: border-box;
+  }
+
+  .mobileLogoIconContainer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
+  .mobileNavBackground {
+    height: 100vh;
+    width: 100%;
+    justify-content: center;
+    padding-top: 2rem;
   }
 
   .hamburger,
@@ -240,11 +256,12 @@
 
   .mobileNav a,
   .meetupLink {
-    font-size: 12px;
+    font-size: 1.5rem;
     font-weight: 700;
     color: hsl(var(--blue));
     text-decoration: none;
-    line-height: 14.09px;
+    text-align: center;
+    margin: 1rem;
 
     &:hover {
       color: hsl(var(--light-blue));

--- a/src/app/components/navbar/navbar.tsx
+++ b/src/app/components/navbar/navbar.tsx
@@ -42,6 +42,7 @@ export default function Navbar() {
       <Link href={link.link} key={link.id}>
         <div
           className={isMobile ? link.mobileClassName : link.desktopClassName}
+          onClick={toggleNav}
         >
           {link.label}
         </div>
@@ -51,44 +52,49 @@ export default function Navbar() {
   return (
     <div className={styles.nav}>
       <nav className={styles.mobileNavBar}>
-        <div className={styles.mobileLogo}>
-          <Link href='/'>
-            <div className={styles.homeLink}>
-              <Image
-                src='/assets/dsd-circle-logo.png'
-                alt='Logo'
-                width={45}
-                height={45}
-              />
-              <span className={styles.home}>{internalLinks.home.label}</span>
+        <div className={styles.mobileLogoIconContainer}>
+          <div className={styles.mobileLogo}>
+            <Link href='/'>
+              <div
+                className={styles.homeLink}
+                onClick={() => setIsNavVisible(false)}
+              >
+                <Image
+                  src='/assets/dsd-circle-logo.png'
+                  alt='Logo'
+                  width={45}
+                  height={45}
+                />
+                <span className={styles.home}>{internalLinks.home.label}</span>
+              </div>
+            </Link>
+          </div>
+          {isNavVisible ? (
+            <div className={styles.crossContainer}>
+              <div
+                onClick={toggleNav}
+                className={styles.cross}
+                data-testid='navbar-collapse'
+              >
+                <div className={styles.line}></div>
+                <div className={styles.line}></div>
+              </div>
             </div>
-          </Link>
-        </div>
-        {isNavVisible ? (
-          <div className={styles.crossContainer}>
+          ) : (
             <div
+              className={styles.hamburger}
               onClick={toggleNav}
-              className={styles.cross}
-              data-testid='navbar-collapse'
+              data-testid='navbar-expand'
             >
               <div className={styles.line}></div>
               <div className={styles.line}></div>
+              <div className={styles.line}></div>
             </div>
-          </div>
-        ) : (
-          <div
-            className={styles.hamburger}
-            onClick={toggleNav}
-            data-testid='navbar-expand'
-          >
-            <div className={styles.line}></div>
-            <div className={styles.line}></div>
-            <div className={styles.line}></div>
-          </div>
-        )}
+          )}
+        </div>
         <div
           className={styles.mobileNavBackground}
-          style={{ display: isNavVisible ? 'block' : 'none' }}
+          style={{ display: isNavVisible ? 'flex' : 'none' }}
         >
           <div className={styles.mobileNav}>
             {navLinks(true)}


### PR DESCRIPTION
Problem: Mobile navbar links were small and therefore hard to click on

Solution Details:

- built a container around the logo and the hamburger/cross icon (className=mobileLogoIconContainer}
- set className=mobileNavBar at the 768 mediaquery to display: flex, flex-direction: column to arrange the mobileLogoIconContainer and the links (mobileNavBackground mobileNav) in a container
- added onClick=toggleNav to the navLinks function so that the nav is toggled to display:none after user
- added same to logo in mobileLogoIconContainer

Possible Bigger Bug:

- The mobileLogoIconContainer width when inspected exceeded the width of the screen (on the 320px wide screen it was 340px for example. I managed this by adding padding-right to the hamburger icon. I noticed that on some smaller screens the video and text are also too far to the right - maybe these are related. 

Expected Behavior:

- match attached images
![mobileNav1](https://github.com/user-attachments/assets/5905fe28-d551-4c77-95ec-84d03ade399d)
![mobileNav2](https://github.com/user-attachments/assets/8386bf13-f2ff-4a80-bd73-6a7d4bb16d01)
- when hamburger is pressed, nav links appear covering page
- when a link is pressed the nav closes and you are taken to the page
- when the cross is pressed the nav closes
- when the logo is pressed you are redirected to the homepage and the nav closes

Future Ideas:
- animate the nav opening, add a smooth transition such as opacity or a quick but gradual drop down from the top
![mobileNav1](https://github.com/user-attachments/assets/5905fe28-d551-4c77-95ec-84d03ade399d)
![mobileNav2](https://github.com/user-attachments/assets/8386bf13-f2ff-4a80-bd73-6a7d4bb16d01)

