### PR TITLE
fix: adjusted cohorts hero highlights css (cohorts-hero)

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -17,17 +17,11 @@
     "<rootDir>/src/**/__tests__/**/*.(test|spec).(js|jsx|ts|tsx)",
     "<rootDir>/src/**/*.(test|spec).(js|jsx|ts|tsx)"
   ],
-  "testPathIgnorePatterns": [
-    "<rootDir>/.next/",
-    "<rootDir>/node_modules/"
-  ],
+  "testPathIgnorePatterns": ["<rootDir>/.next/", "<rootDir>/node_modules/"],
   "collectCoverageFrom": [
     "src/**/*.{js,jsx,ts,tsx}",
     "!src/**/*.d.ts",
     "!src/**/*.stories.{js,jsx,ts,tsx}"
   ],
-  "coveragePathIgnorePatterns": [
-    "<rootDir>/node_modules/",
-    "<rootDir>/.next/"
-  ]
+  "coveragePathIgnorePatterns": ["<rootDir>/node_modules/", "<rootDir>/.next/"]
 }

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -167,7 +167,9 @@ export async function getSpeakers(): Promise<Speaker[]> {
         photoUrl: photoUrl || '/assets/person.svg',
         linkedin: fields.linkedin,
         lastSpoke: fields.lastSpoke,
-        topics: fields.topics ? normalizeTopic(fields.topics).split(', ') : undefined,
+        topics: fields.topics
+          ? normalizeTopic(fields.topics).split(', ')
+          : undefined,
       };
     });
 

--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -113,6 +113,7 @@
 @media (max-width: 768px) {
   .button {
     width: 100%;
+    max-width: 576px;
     font-size: 13px;
   }
 
@@ -123,6 +124,10 @@
 }
 
 @media (max-width: 480px) {
+  .button {
+    max-width: 320px;
+  }
+
   .button--primary,
   .button--secondary {
     height: 2.4rem;

--- a/src/components/cohortsHero/cohortsHero.module.css
+++ b/src/components/cohortsHero/cohortsHero.module.css
@@ -1,7 +1,7 @@
 .hero {
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: auto;
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -350,8 +350,8 @@
   }
 
   .highlightItem:nth-child(3) {
-    width: calc(50% - var(--spacing-2));
-    max-width: 220px;
+    width: 100%;
+    max-width: 576px;
     margin-top: var(--spacing-3);
   }
 
@@ -393,7 +393,7 @@
 
   .highlightItem:nth-child(3) {
     width: auto;
-    max-width: none;
+    max-width: 320px;
     margin-top: 0;
   }
 
@@ -425,7 +425,7 @@
 
   .highlightItem {
     width: calc(50% - var(--spacing-half));
-    max-width: 140px;
+    max-width: 320px;
     min-height: 80px;
     padding: var(--spacing-1);
   }


### PR DESCRIPTION
I adjusted the cohorts hero container height to auto, to allow the highlight cards to fully display.  I also adjusted the width properties for the highlight cards to improve the display on 480x and 768px breakpoints.

# Current Design (480px and below)
<img width="469" height="824" alt="Image" src="https://github.com/user-attachments/assets/429d6762-d7ad-4eb0-8eaa-583955c745e6" />

# Suggested equal sizing (including CTA button)
<img width="469" height="824" alt="Image" src="https://github.com/user-attachments/assets/8054828e-dc60-4b07-b6cd-19188a8891d5" />

# Current Design (481px to 768px)
<img width="657" height="824" alt="Image" src="https://github.com/user-attachments/assets/93f11771-b5ae-4108-ab01-927ee49ca878" />

# Suggested sizing
<img width="671" height="824" alt="Dallas-Software-Developers-09-29-2025_09_50_AM" src="https://github.com/user-attachments/assets/1c24a2ab-fe00-4935-a741-66898ca8f3af" />
